### PR TITLE
Popstarfreas changes

### DIFF
--- a/src/ChildProcess.res
+++ b/src/ChildProcess.res
@@ -209,6 +209,7 @@ external execSyncOptions: (
   ~killSignal: string=?,
   ~uid: int=?,
   ~gid: int=?,
+  ~stdio: string=?,
   ~windowsHide: bool=?,
   unit,
 ) => execSyncOptions = ""

--- a/src/Fs.res
+++ b/src/Fs.res
@@ -393,9 +393,6 @@ external open_: (string, Flag.t) => Js.Promise.t<FileHandle.t> = "open"
 @module("fs") @scope("promises")
 external openWithMode: (string, Flag.t, ~mode: int) => Js.Promise.t<FileHandle.t> = "open"
 
-@module("fs") @scope("promises")
-external readFile: (string, readFileOptions) => Js.Promise.t<Buffer.t> = "readFile"
-
 module WriteStream = {
   type kind<'w> = [Stream.writable<'w> | #FileSystem]
   type subtype<'w, 'ty> = Stream.subtype<[> kind<'w>] as 'ty>

--- a/src/Fs.res
+++ b/src/Fs.res
@@ -243,7 +243,10 @@ external rmdirSync: string => unit = "rmdirSync"
 external openSyncWith: (string, ~flag: Flag.t=?, ~mode: int=?) => fd = "openSync"
 
 @module("fs")
-external readFileSync: (string, ~options: readFileOptions=?, unit) => Buffer.t = "readFileSync"
+external readFileSync: (string) => Buffer.t = "readFileSync"
+@module("fs")
+external readFileSyncWith: (string, readFileOptions) => Buffer.t = "readFileSync"
+
 @module("fs") external existsSync: string => bool = "existsSync"
 
 @val @module("fs")

--- a/src/Fs.res
+++ b/src/Fs.res
@@ -393,6 +393,9 @@ external open_: (string, Flag.t) => Js.Promise.t<FileHandle.t> = "open"
 @module("fs") @scope("promises")
 external openWithMode: (string, Flag.t, ~mode: int) => Js.Promise.t<FileHandle.t> = "open"
 
+@module("fs") @scope("promises")
+external readFile: (string, readFileOptions) => Js.Promise.t<Buffer.t> = "readFile"
+
 module WriteStream = {
   type kind<'w> = [Stream.writable<'w> | #FileSystem]
   type subtype<'w, 'ty> = Stream.subtype<[> kind<'w>] as 'ty>

--- a/src/Http.res
+++ b/src/Http.res
@@ -708,6 +708,7 @@ external requestOptions: (
   ~setHost: bool=?,
   ~socketPath: string=?,
   ~timeout: int=?,
+  unit,
 ) => requestOptions = ""
 
 @module("http") external request: string => ClientRequest.t = "request"

--- a/src/Https.res
+++ b/src/Https.res
@@ -30,3 +30,15 @@ module Agent = {
   }
   include Events
 }
+
+@module("https") external get: string => Http.ClientRequest.t = "get"
+@module("https")
+external getWithCallback: (string, Http.IncomingMessage.t => unit) => Http.ClientRequest.t = "get"
+@module("https")
+external getWithOptions: (string, Http.requestOptions) => Http.ClientRequest.t = "get"
+@module("https")
+external getWithOptionsCallback: (
+  string,
+  Http.requestOptions,
+  Http.IncomingMessage.t => unit,
+) => Http.ClientRequest.t = "get"

--- a/src/Https.res
+++ b/src/Https.res
@@ -31,6 +31,29 @@ module Agent = {
   include Events
 }
 
+@module("https") external request: string => Http.ClientRequest.t = "request"
+@module("https")
+external requestWithCallback: (string, Http.IncomingMessage.t => unit) => Http.ClientRequest.t = "request"
+@module("https")
+external requestWithOptions: (string, Http.requestOptions) => Http.ClientRequest.t = "request"
+@module("https")
+external requestWithOptionsCallback: (
+  string,
+  Http.requestOptions,
+  Http.IncomingMessage.t => unit,
+) => Http.ClientRequest.t = "request"
+@module("https") external requestUrl: Url.t => Http.ClientRequest.t = "request"
+@module("https")
+external requestUrlWithCallback: (Url.t, Http.IncomingMessage.t => unit) => Http.ClientRequest.t = "request"
+@module("https")
+external requestUrlWithOptions: (Url.t, Http.requestOptions) => Http.ClientRequest.t = "request"
+@module("https")
+external requestUrlWithOptionsCallback: (
+  Url.t,
+  Http.requestOptions,
+  Http.IncomingMessage.t => unit,
+) => Http.ClientRequest.t = "request"
+
 @module("https") external get: string => Http.ClientRequest.t = "get"
 @module("https")
 external getWithCallback: (string, Http.IncomingMessage.t => unit) => Http.ClientRequest.t = "get"
@@ -42,3 +65,24 @@ external getWithOptionsCallback: (
   Http.requestOptions,
   Http.IncomingMessage.t => unit,
 ) => Http.ClientRequest.t = "get"
+
+@module("https") external getUrl: Url.t => Http.ClientRequest.t = "get"
+@module("https")
+external getUrlWithCallback: (Url.t, Http.IncomingMessage.t => unit) => Http.ClientRequest.t = "get"
+@module("https")
+external getUrlWithOptions: (Url.t, Http.requestOptions) => Http.ClientRequest.t = "get"
+@module("https")
+external getUrlWithOptionsCallback: (
+  Url.t,
+  Http.requestOptions,
+  Http.IncomingMessage.t => unit,
+) => Http.ClientRequest.t = "get"
+
+@module("https") external globalAgent: Agent.t = "globalAgent"
+@module("https") external maxHeaderSize: int = "maxHeaderSize"
+
+type statusCodes = Js.Dict.t<string>
+@module("https") external _STATUS_CODES: statusCodes = "STATUS_CODES"
+
+type methods = array<string>
+@module("https") external _METHODS: methods = "METHODS"

--- a/src/Net.res
+++ b/src/Net.res
@@ -219,7 +219,7 @@ module Socket = {
       ~delay: int,
     ) => subtype<'w, 'r, 'ty> = "setKeepAlive"
     @send
-    external setNoDelay: (subtype<'w, 'r, 'ty>, ~noDelay: bool) => subtype<'w, 'r, 'ty> = "noDelay"
+    external setNoDelay: (subtype<'w, 'r, 'ty>, ~noDelay: bool) => subtype<'w, 'r, 'ty> = "setNoDelay"
     @send
     external setTimeout: (
       subtype<'w, 'r, 'ty>,

--- a/src/Net.res
+++ b/src/Net.res
@@ -243,6 +243,9 @@ module Socket = {
     ) => 'tcpSocket = "connect"
   }
   include Impl
+  include EventEmitter.Impl({
+      type t = t
+  })
 
   type makeOptions
 

--- a/src/Zlib.res
+++ b/src/Zlib.res
@@ -1,0 +1,4 @@
+@module("zlib") external deflateRawSync: Buffer.t => Buffer.t = "deflateRawSync"
+@module("zlib") external deflateRaw: (Buffer.t, (. Buffer.t) => unit) => unit = "deflateRaw"
+@module("zlib") external inflateRawSync: Buffer.t => Buffer.t = "inflateRawSync"
+@module("zlib") external inflateRaw: (Buffer.t, (. Buffer.t) => unit) => unit = "inflateRaw"


### PR DESCRIPTION
Pulled in a bunch of maintenance done by @popstarfreas with cherry-pick from:
https://github.com/popstarfreas/rescript-nodejs

I left out the collapse of `fs` methods that take options; I'd rather not break the API that much (and I find I prefer multiple methods over forcing every method call to add unit after the optional argument).