### PR TITLE
fix: makes name consistent

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "reason-nodejs",
+  "name": "rescript-nodejs",
   "sources": [
     {
       "dir": "src",


### PR DESCRIPTION
This change aims to keep both `package.json` and `bsconfig.json` name fields consistent.

It also makes consistent the code and the README file