### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Node.js bindings for ReScript
 ## Installation
 
 ```shell
-npm i add rescript-nodejs
+npm install rescript-nodejs
 ```
 or
 ```shell


### PR DESCRIPTION
Also, think it is better to write `install` out in full for readmes (rather than `i`).