### PR TITLE
Fix to runInContext, runInNewContext and runInThisContext signature

### DIFF
--- a/.changes/unreleased/Fixed-20240124-121124.yaml
+++ b/.changes/unreleased/Fixed-20240124-121124.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Corrected `VM` method signatures `runInContext`, `runInNewContext` and `runInThisContext`
+time: 2024-01-24T12:11:24.898655+11:00
+custom:
+  GithubIssue: "23"

--- a/src/VM.res
+++ b/src/VM.res
@@ -25,8 +25,8 @@ module Script = {
   external makeWithOptions: (string, options) => t = "Script"
   @send external createCachedData: t => Buffer.t = "createCachedData"
   @send
-  external runInContext: (t, string, contextifiedObject<'a>) => 'b = "runInContext"
+  external runInContext: (t, contextifiedObject<'a>) => 'b = "runInContext"
   @send
-  external runInNewContext: (t, string, contextifiedObject<'a>) => 'b = "runInNewContext"
-  @send external runInThisContext: (t, string) => 'a = "runInThisContext"
+  external runInNewContext: (t,  contextifiedObject<'a>) => 'b = "runInNewContext"
+  @send external runInThisContext: t => 'a = "runInThisContext"
 }


### PR DESCRIPTION
According to https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options, these three functions don't have a second parameter of string type.

These three functions didn't work in my project after build, an exception would be raised, so I fixed this.