### PR TITLE
Add open NodeJs to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Help all ReScript Node.js apps and libraries to be built faster by reducing the 
 ### Stream a file into stdout:
 
 ```rescript
+open NodeJs
+
 Fs.createReadStream("/path")
   ->Stream.pipe(Process.(stdout(process)))
   ->Stream.onError(_ => Js.log("handleError"))
@@ -54,6 +56,8 @@ Fs.createReadStream("/path")
 ### Echo server:
 
 ```rescript
+open NodeJs
+
 Http.createServer((request, response) => {
   request->Stream.onData(data => Js.log(data))
   request->Stream.pipe(response)->ignore

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Help all ReScript Node.js apps and libraries to be built faster by reducing the 
 open NodeJs
 
 Fs.createReadStream("/path")
-  ->Stream.pipe(Process.(stdout(process)))
+  ->Stream.pipe(Process.stdout(Process.process))
   ->Stream.onError(_ => Js.log("handleError"))
 ```
 


### PR DESCRIPTION
Just to make the readme examples possible to copy-paste and run without anything extra.